### PR TITLE
Fixes/iteration 2023 01

### DIFF
--- a/.github/ISSUE_TEMPLATE/course-instance.md
+++ b/.github/ISSUE_TEMPLATE/course-instance.md
@@ -16,6 +16,7 @@ assignees: ""
   - breaking changes in React, React Router, other tools?
   - any new features to include?
 - [ ] Dev tools work (e.g. with current Node.js version)
+- [ ] Order a new collectors link for the Survey Monkey feedback form. Each link is different but points to the same form (e.g., [Feedback Form](https://de.surveymonkey.com/r/PTSDCGT))
 
 ### Latest 1 week before course
 
@@ -41,15 +42,16 @@ assignees: ""
 
 | Chapter          | Assigned to |
 | ---------------- | ----------- |
-| Intro            | Felix       |
-| Setup            | Moritz      |
-| First Components | Moritz      |
-| Hooks            | Felix       |
-| Data Fetching    | Felix       |
-| Routing          | Felix       |
-| Forms            | Moritz      |
-| State Management | Moritz      |
-| Styling          | Felix       |
+| Intro            | TBD         |
+| Setup            | TBD         |
+| First Components | TBD         |
+| Hooks            | TBD         |
+| Data Fetching    | TBD         |
+| Routing          | TBD         |
+| Forms            | TBD         |
+| SideEffects      | TBD         |
+| State Management | TBD         |
+| Styling          | TBD         |
 
 ### Moderation
 

--- a/slides/01_Intro.html
+++ b/slides/01_Intro.html
@@ -96,6 +96,25 @@
         </section>
         <section>
           <section>
+            <h2>Miro Board</h2>
+            <p>Rate your React experience and course expectancy</p>
+            <p>Link will be posted in the teams chat</p>
+          </section>
+          <section>
+            <p>Follow the presentation here</p>
+            <p>
+              <a
+                href="https://webplatformz.github.io/react-training-slides-v2/"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                https://webplatformz.github.io/react-training-slides-v2/
+              </a>
+            </p>
+          </section>
+        </section>
+        <section>
+          <section>
             <h2>Course structure</h2>
             <ul>
               <li>Theoretical input</li>
@@ -120,6 +139,7 @@
             </p>
           </section>
         </section>
+
         <section>
           <section>
             <h2>About React</h2>

--- a/slides/01_Intro.html
+++ b/slides/01_Intro.html
@@ -2,7 +2,10 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
+    />
 
     <title>Intro | Essential React</title>
 
@@ -142,7 +145,8 @@
             <p class="fragment">
               There are also
               <span class="warn">full-featured frameworks</span>
-              based on React, which target common use cases (e.g. Next.js, Remix).
+              based on React, which target common use cases (e.g. Next.js,
+              Remix).
             </p>
           </section>
           <section>
@@ -209,10 +213,10 @@
             <pre><code class="hljs js" data-trim><script type="text/template">
                   const fruits = ["banana", "apple", "orange"];
                     
-                    const [firstFruit, secondFruit] = fruits;
+                  const [firstFruit, secondFruit] = fruits;
 
-                    console.log(firstFruit); // "banana"
-                    console.log(secondFruit); // "apple"
+                  console.log(firstFruit); // "banana"
+                  console.log(secondFruit); // "apple"
                 </script></code></pre>
           </section>
           <section>

--- a/slides/05_First_Components.html
+++ b/slides/05_First_Components.html
@@ -621,7 +621,7 @@
                 Create a (hard-coded)
                 <a target="_blank" href="https://pokeapi.co/api/v2/pokemon?limit=50">array of Pokémon</a>
               </li>
-              <li class="fragment">Render all Pokémon names in a list</li>
+              <li class="fragment">Render all Pokémon names in a list (hint: add a new <span class="code">PokeEntry.tsx</span> component)</li>
               <li class="fragment">
                 Make the name in
                 <span class="code">PokeListEntry.tsx</span>

--- a/slides/05_First_Components.html
+++ b/slides/05_First_Components.html
@@ -429,7 +429,7 @@
                     <code class="hljs javascript" data-trim>
                         <script type="text/template">
                         it.each(['Bulbasaur', 'Eevee', 'Pickachu'])
-                          ('should render the passed pokémon name', (name) => {
+                          ('should render the passed pokémon %s', (name) => {
                           render(<PokeListEntry name={name} />);
                           expect(screen.getByText(name)).toBeInTheDocument();
                         });

--- a/slides/12_Styling.html
+++ b/slides/12_Styling.html
@@ -264,6 +264,10 @@
                 ⭐️
               </li>
               <li>
+                <a href="https://vanilla-extract.style/" target="_blank" rel="noopener noreferrer">vanilla-extract</a>
+                (compiled to css)
+              </li>
+              <li>
                 <a href="https://emotion.sh/" target="_blank" rel="noopener noreferrer">Emotion</a>
               </li>
               <li>

--- a/slides/13_Various.html
+++ b/slides/13_Various.html
@@ -543,25 +543,24 @@ export default handlers;
               data-id="code"
             ><code class="hljs tsx" data-trim data-line-numbers="1,7-11,14-17"><script type="text/template">
                     class ErrorBoundary extends React.Component {
-                    constructor(props) {
+                      constructor(props) {
                         super(props);
                         this.state = { hasError: false };
-                    }
+                      }
                         
-                    static getDerivedStateFromError(error) {
-                        /* Update state so the next render will show
-                           the fallback UI. */
+                      static getDerivedStateFromError(error) {
+                          /* Update state so the next render will show
+                            the fallback UI. */
                         return { hasError: true };
-                    }
-                    
-                    render() {
+                      }
+                      
+                      render() {
                         if (this.state.hasError) {
-                        /* You can render any custom fallback UI */
-                        return <h1>Something went wrong.</h1>;
+                          /* You can render any custom fallback UI */
+                          return <h1>Something went wrong.</h1>;
                         }
-                        
                         return this.props.children; 
-                    }
+                      }
                     }
             </script></code></pre>
           </section>
@@ -636,7 +635,7 @@ export default handlers;
           <section data-auto-animate>
             <h2>React Server Components (RSC)</h2>
             <ul>
-              <li>Still in development</li>
+              <li>Available in React (not yet nextjs)</li>
               <li>Different from server-side rendering</li>
               <li>Server components are never rendered on the client</li>
             </ul>


### PR DESCRIPTION
**Questions:**
* JSX mention fileending *.jsx / *.tsx as well? if you go *.js / *.ts, the struggle is big :)
* Setup suggestions? Mention Prettier/ESLint Plugins in before? Autosave in VS Code? Format on Save?
* useReducer Excercise without Context or prop drilling as a sample? So that it's more local and the people can focus on the useReducer behaviour.

**TODO:**

- [ ] First Component Props: How to pass them is not mentioned
- [ ] Hooks: Add stretch goal on how to test useState hook & add a solution -> maybe move to separate ticket? https://testing-library.com/docs/user-event/utility/#type
- [ ] Data Fetching: Add stretch goal on how to test the PokeList component & add a solution -> maybe move to separate ticket? 
- [ ] Do 'marketing slide' for the CSS course in the styling chapter?
- [ ] Custom Hooks better explanation / sample pages (in theory)
- [ ] Use simpler example for useEffect (for example the one beta.react.js with chatroom)


**Ideas:** 
* Generic Props?
* Mentioning official doc & beta doc?